### PR TITLE
Add hashCode test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ We are not responsible for any harm or damage caused by your use of our Software
 If you do not agree with this disclaimer, please do not use our Software. Your use of our Software signifies your agreement with this disclaimer.
 
 This disclaimer is subject to change without notice, and it is your responsibility to review this disclaimer periodically to ensure you are aware of its terms.
+
+## Testing
+
+Run unit tests using Node.js:
+
+```sh
+npm test
+```
+

--- a/hashCode.js
+++ b/hashCode.js
@@ -1,0 +1,10 @@
+'use strict';
+function hashCode(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash) + str.charCodeAt(i);
+    hash |= 0; // Convert to 32bit integer
+  }
+  return hash;
+}
+module.exports = hashCode;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "esoteric-firefox-userscripts",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node tests/hashCode.test.js"
+  }
+}

--- a/tests/hashCode.test.js
+++ b/tests/hashCode.test.js
@@ -1,0 +1,13 @@
+'use strict';
+const assert = require('assert');
+const hashCode = require('../hashCode');
+
+const input = 'sample input';
+const first = hashCode(input);
+const second = hashCode(input);
+
+assert.strictEqual(first, second, 'hashCode should be deterministic');
+assert.strictEqual(typeof first, 'number', 'hashCode result should be a number');
+assert.ok(first <= 2147483647 && first >= -2147483648, 'hashCode result should be a 32-bit signed integer');
+
+console.log('hashCode tests passed');


### PR DESCRIPTION
## Summary
- add Node-based `hashCode` helper module
- provide a simple test in `tests/hashCode.test.js`
- define npm test script
- document how to run the tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b85b0f93083338b19a44671881448